### PR TITLE
fix insecure decrypt functions

### DIFF
--- a/src/main/java/com/neilalexander/jnacl/NaCl.java
+++ b/src/main/java/com/neilalexander/jnacl/NaCl.java
@@ -78,7 +78,7 @@ public class NaCl {
     byte[] paddedoutput = new byte[input.length];
     byte[] output = new byte[input.length - crypto_secretbox_ZEROBYTES];
 
-    curve25519xsalsa20poly1305.crypto_box_afternm(paddedoutput, input, input.length, nonce, this.precomputed);
+    curve25519xsalsa20poly1305.crypto_box_open_afternm(paddedoutput, input, input.length, nonce, this.precomputed);
     System.arraycopy(paddedoutput, crypto_secretbox_ZEROBYTES, output, 0, paddedoutput.length - crypto_secretbox_ZEROBYTES);
 
     return output;
@@ -88,7 +88,7 @@ public class NaCl {
     byte[] paddedoutput = new byte[inputlength];
     byte[] output = new byte[inputlength - crypto_secretbox_ZEROBYTES];
 
-    curve25519xsalsa20poly1305.crypto_box_afternm(paddedoutput, input, inputlength, nonce, this.precomputed);
+    curve25519xsalsa20poly1305.crypto_box_open_afternm(paddedoutput, input, inputlength, nonce, this.precomputed);
     System.arraycopy(paddedoutput, crypto_secretbox_ZEROBYTES, output, 0, paddedoutput.length - crypto_secretbox_ZEROBYTES);
 
     return output;


### PR DESCRIPTION
Doing a decrypt with the encryption function crypto_box_afternm works, by the magic of math, but it is simply wrong! Because then there is no check of the Poly1305 checksum, to find out whether the message was forked. Without this check the whole encryption is useless.