### PR TITLE
Changes for compatibility with Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>eu.neilalexander</groupId>
   <artifactId>jnacl</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>
@@ -15,7 +15,7 @@
     <url>git@github.com:neilalexander/jnacl.git</url>
     <connection>scm:git:git@github.com:neilalexander/jnacl.git</connection>
     <developerConnection>scm:git:git@github.com:neilalexander/jnacl.git</developerConnection>
-    <tag>v1.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>eu.neilalexander</groupId>
   <artifactId>jnacl</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>
@@ -15,7 +15,7 @@
     <url>git@github.com:neilalexander/jnacl.git</url>
     <connection>scm:git:git@github.com:neilalexander/jnacl.git</connection>
     <developerConnection>scm:git:git@github.com:neilalexander/jnacl.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v1.0.0</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.neilalexander</groupId>
+  <groupId>eu.neilalexander</groupId>
   <artifactId>jnacl</artifactId>
-  <version>1.0</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
After some requests the project is published to Maven Central now.

It is available for use by including the following dependency

```text
<dependency>
    <groupId>eu.neilalexander</groupId>
    <artifactId>jnacl</artifactId>
    <version>1.0.0</version>
</dependency>
```

---

Describing this pull request, the commits should not be squashed together but merged to master. 
A tag `v1.0.0` should be created pointing to 3f61ee4
